### PR TITLE
searcher: actually advance the search cursor

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -16192,9 +16192,9 @@ function tripletMatchesSystem(triplet) {
  */
 async function* getReleases(client, repo) {
     const [owner, name] = repo.split('/');
-    let hasNextPage = false;
-    do {
-        let endCursor = null;
+    let endCursor = null;
+    let hasNextPage = true;
+    while (hasNextPage) {
         const { repository: { releases: { edges: releaseEdges, pageInfo } } } = await client.graphql(`
         query ($owner: String!, $name: String!, $endCursor: String, $order: ReleaseOrder!) {
           repository(owner: $owner, name: $name) {
@@ -16226,7 +16226,7 @@ async function* getReleases(client, repo) {
         for (const { node: { id, tagName } } of releaseEdges) {
             yield { id: id, tag: tagName };
         }
-    } while (hasNextPage);
+    }
 }
 
 

--- a/searcher.ts
+++ b/searcher.ts
@@ -235,12 +235,12 @@ function tripletMatchesSystem(triplet: string): boolean {
  *
  * @return The release tag name.
  */
-async function* getReleases(client: Octokit, repo: String): AsyncGenerator<Release> {
+async function* getReleases(client: Octokit, repo: string): AsyncGenerator<Release> {
   const [ owner, name ] = repo.split('/');
 
-  let hasNextPage = false;
-  do {
-    let endCursor = null;
+  let endCursor = null;
+  let hasNextPage = true;
+  while (hasNextPage) {
     const {
       repository: {
         releases: {
@@ -248,7 +248,7 @@ async function* getReleases(client: Octokit, repo: String): AsyncGenerator<Relea
           pageInfo
         }
       }
-    } = await client.graphql(
+    }: any = await client.graphql(
       `
         query ($owner: String!, $name: String!, $endCursor: String, $order: ReleaseOrder!) {
           repository(owner: $owner, name: $name) {
@@ -284,5 +284,5 @@ async function* getReleases(client: Octokit, repo: String): AsyncGenerator<Relea
     for (const { node: { id, tagName } } of releaseEdges) {
       yield {id: id, tag: tagName};
     }
-  } while (hasNextPage);
+  }
 }


### PR DESCRIPTION
The cursor was not advanced on every search due as it is in the loop
body, causing infinite loops when the version requested was not one of
the latest 10 versions.