### PR TITLE
test: fix filter job output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     name: Check if tests should be run
     runs-on: ubuntu-latest
     outputs:
-      should-skip: ${{ steps.filter.should_skip }}
+      should-skip: ${{ steps.filter.outputs.should_skip }}
 
     steps:
       - uses: fkirc/skip-duplicate-actions@v5.3.1


### PR DESCRIPTION
Previously this referred to the wrong attribute, causing the skip output to not propagate correctly to next jobs