### PR TITLE
test: separate macOS ARM and macOS x86 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,20 +36,27 @@ jobs:
     if: needs.filter.outputs.should-skip != 'true'
     strategy:
       matrix:
-        runner: [ubuntu-latest, macos-latest, windows-latest]
+        runner: [ubuntu-latest, macos-latest, macos-13, windows-latest]
         spec:
-          - 0.1.0-dev.21195
+          - 0.1.0-dev.21199
           - "*"
           - ">0.0.0"
           - ">0.1.0-dev.20066 <0.1.0-dev.20074"
+          - ">0.1.0-dev.21330 <0.1.0-dev.21332"
         include:
-          - spec: 0.1.0-dev.21195
-            expect: 0.1.0-dev.21195
+          - spec: 0.1.0-dev.21199
+            expect: 0.1.0-dev.21199
           - spec: ">0.1.0-dev.20066 <0.1.0-dev.20074"
             expect: 0.1.0-dev.20072
+          - spec: ">0.1.0-dev.21330 <0.1.0-dev.21332"
+            expect: 0.1.0-dev.21331
         exclude:
           # Windows is not supported by this version
           - runner: windows-latest
+            spec: ">0.1.0-dev.20066 <0.1.0-dev.20074"
+
+          # ARM macOS is not supported by this version
+          - runner: macos-latest
             spec: ">0.1.0-dev.20066 <0.1.0-dev.20074"
 
     name: Test installation for spec ${{ matrix.spec }} on ${{ matrix.runner }}


### PR DESCRIPTION
With GitHub migrating macos-latest label to the ARM runner, our periodic CIs are failing since the commit referred by the test constraint does not have support for ARM macOS.

This commit adds a new "complex" constraint that supports all targets tested at the moment, and adds a separate runner for x86 macOS.